### PR TITLE
Mss 317 get tags from asg

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "simple-configuration"
 organization := "com.gu"
 
 val scala_2_11: String = "2.11.12"
-val scala_2_12: String = "2.12.4"
+val scala_2_12: String = "2.12.6"
 
-val awsSdkVersion = "1.11.282"
+val awsSdkVersion = "1.11.354"
 
 scalaVersion := scala_2_11
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,7 @@ val core = project
     name := "simple-configuration-core",
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-autoscaling" % awsSdkVersion,
       "com.typesafe" % "config" % "1.3.3",
       "org.slf4j" % "slf4j-api" % "1.7.25"
     )

--- a/core/src/main/scala/com/gu/AppIdentity.scala
+++ b/core/src/main/scala/com/gu/AppIdentity.scala
@@ -53,7 +53,7 @@ object AppIdentity {
         val describeAutoScalingInstancesResult = asgClient.describeAutoScalingInstances(describeAutoScalingInstancesRequest)
         describeAutoScalingInstancesResult.getAutoScalingInstances.asScala.head.getAutoScalingGroupName
       }
-      val tags = {
+      val tags: Map[String, String] = {
         val describeAutoScalingGroupsRequest = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(autoscalingGroupName)
         val describeAutoScalingGroupsResult = asgClient.describeAutoScalingGroups(describeAutoScalingGroupsRequest)
         val autoScalingGroup = describeAutoScalingGroupsResult.getAutoScalingGroups.asScala.head

--- a/core/src/main/scala/com/gu/AppIdentity.scala
+++ b/core/src/main/scala/com/gu/AppIdentity.scala
@@ -48,19 +48,17 @@ object AppIdentity {
     }
 
     def getTags(asgClient: AmazonAutoScaling): Map[String, String] = {
-      val autoscalingGroupName = {
-        val describeAutoScalingInstancesRequest = new DescribeAutoScalingInstancesRequest().withInstanceIds(instanceId)
-        val describeAutoScalingInstancesResult = asgClient.describeAutoScalingInstances(describeAutoScalingInstancesRequest)
-        describeAutoScalingInstancesResult.getAutoScalingInstances.asScala.head.getAutoScalingGroupName
-      }
-      val tags: Map[String, String] = {
-        val describeAutoScalingGroupsRequest = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(autoscalingGroupName)
-        val describeAutoScalingGroupsResult = asgClient.describeAutoScalingGroups(describeAutoScalingGroupsRequest)
-        val autoScalingGroup = describeAutoScalingGroupsResult.getAutoScalingGroups.asScala.head
-        autoScalingGroup.getTags.asScala.map { t => t.getKey -> t.getValue }(scala.collection.breakOut)
-      }
-      tags
+      val describeAutoScalingInstancesRequest = new DescribeAutoScalingInstancesRequest().withInstanceIds(instanceId)
+      val describeAutoScalingInstancesResult = asgClient.describeAutoScalingInstances(describeAutoScalingInstancesRequest)
+      val autoScalingGroupName = describeAutoScalingInstancesResult.getAutoScalingInstances.asScala.head.getAutoScalingGroupName
+
+      val describeAutoScalingGroupsRequest = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(autoScalingGroupName)
+      val describeAutoScalingGroupsResult = asgClient.describeAutoScalingGroups(describeAutoScalingGroupsRequest)
+      val autoScalingGroup = describeAutoScalingGroupsResult.getAutoScalingGroups.asScala.head
+
+      autoScalingGroup.getTags.asScala.map { t => t.getKey -> t.getValue }(scala.collection.breakOut)
     }
+
     val tags = withOneOffAsgClient(getTags)
     AwsIdentity(
       app = tags("App"),


### PR DESCRIPTION
EC2 Instance Tags appear to be eventually consistent.
ASG ones are apparently safer, so swapping to those instead.