### PR TITLE
Add ComposedConfigurationLocation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -172,6 +172,9 @@ This will be useful when loading a file ouside of your classpath. Typically, a c
 ### ResourceConfigurationLocation
 This will load a configuration file from within your classpath. Typically a file under the `resource` folder of your project. It is useful if your configuration can be committed in your repo and is directly accessible from the classpath. 
 
+### ComposedConfigurationLocation
+Composes a list of `ConfigurationLocation`s. Configurations earlier in the list take precedence over ones later in the list.
+
 ## IAM permissions
 - if you use `AppIdentity.whoAmI` on an ec2 instance. Note that you won't need that for a lambda as these are passed as environment variables
 ```json

--- a/core/src/main/scala/com/gu/conf/ConfigurationLocation.scala
+++ b/core/src/main/scala/com/gu/conf/ConfigurationLocation.scala
@@ -16,3 +16,12 @@ case class FileConfigurationLocation(file: File) extends ConfigurationLocation {
 case class ResourceConfigurationLocation(resourceName: String) extends ConfigurationLocation {
   override def load(credentials: => AWSCredentialsProvider): Config = ConfigFactory.parseResources(resourceName)
 }
+
+case class ComposedConfigurationLocation(locations: List[ConfigurationLocation]) extends ConfigurationLocation {
+  override def load(credentials: => AWSCredentialsProvider): Config = {
+    val aggregatedConfig = locations.map(_.load(credentials)).foldLeft(ConfigFactory.empty()) {
+      case (agg, loadedConfig) => agg.withFallback(loadedConfig)
+    }
+    aggregatedConfig.resolve()
+  }
+}


### PR DESCRIPTION
First implemented [here](https://github.com/guardian/mobile-apps-api/blob/master/common-play/src/main/scala/conf/MobileAppsApiConfiguration.scala#L45-L63), now needed by other projects