### PR TITLE
Upgrade AWS SDK to v2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,15 +7,18 @@ val scala_2_11: String = "2.11.12"
 val scala_2_12: String = "2.12.11"
 val scala_2_13: String = "2.13.2"
 
-val awsSdkVersion = "1.11.772"
+val awsSdkVersion = "2.15.33"
 
 scalaVersion := scala_2_11
 
 val sharedSettings = Seq(
   scalaVersion := scala_2_11,
+  scalacOptions += "-target:jvm-1.8",
   crossScalaVersions := Seq(scala_2_11, scala_2_12, scala_2_13),
   releaseCrossBuild := true,
-  licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html")),
+  licenses += ("Apache-2.0", url(
+    "http://www.apache.org/licenses/LICENSE-2.0.html"
+  )),
   organization := "com.gu",
   bintrayOrganization := Some("guardian"),
   bintrayRepository := "platforms",
@@ -41,8 +44,8 @@ val core = project
   .settings(
     name := "simple-configuration-core",
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
-      "com.amazonaws" % "aws-java-sdk-autoscaling" % awsSdkVersion,
+      "software.amazon.awssdk" % "ec2" % awsSdkVersion,
+      "software.amazon.awssdk" % "autoscaling" % awsSdkVersion,
       "com.typesafe" % "config" % "1.4.0",
       "org.slf4j" % "slf4j-api" % "1.7.30"
     )
@@ -53,9 +56,7 @@ val s3 = project
   .dependsOn(core)
   .settings(
     name := "simple-configuration-s3",
-    libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion
-    )
+    libraryDependencies ++= Seq("software.amazon.awssdk" % "s3" % awsSdkVersion)
   )
 
 val ssm = project
@@ -64,15 +65,15 @@ val ssm = project
   .settings(
     name := "simple-configuration-ssm",
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion
+      "software.amazon.awssdk" % "ssm" % awsSdkVersion
     )
   )
 
-lazy val root = project.in(file("."))
+lazy val root = project
+  .in(file("."))
   .aggregate(core, s3, ssm)
   .settings(
     publish := {},
     releaseCrossBuild := true,
     crossScalaVersions := Seq(scala_2_11, scala_2_12, scala_2_13)
   )
-

--- a/core/src/main/scala/com/gu/AppIdentity.scala
+++ b/core/src/main/scala/com/gu/AppIdentity.scala
@@ -1,62 +1,82 @@
 package com.gu
 
-import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.autoscaling.model.{DescribeAutoScalingGroupsRequest, DescribeAutoScalingInstancesRequest}
-import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClientBuilder}
-import com.amazonaws.util.EC2MetadataUtils
 import org.slf4j.LoggerFactory
+import software.amazon.awssdk.auth.credentials.{
+  AwsCredentialsProvider,
+  DefaultCredentialsProvider
+}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.autoscaling.model.{
+  DescribeAutoScalingGroupsRequest,
+  DescribeAutoScalingInstancesRequest
+}
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 sealed trait AppIdentity
 
-case class AwsIdentity(
-                        app: String,
-                        stack: String,
-                        stage: String,
-                        region: String
-                      ) extends AppIdentity
+case class AwsIdentity(app: String,
+                       stack: String,
+                       stage: String,
+                       region: String)
+    extends AppIdentity
 
-case class DevIdentity(
-                        app: String
-                      ) extends AppIdentity
+case class DevIdentity(app: String) extends AppIdentity
 
 object AppIdentity {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private def safeAwsOperation[A](errorMessage: => String)(operation: => A): Option[A] = Try(operation) match {
+  private def safeAwsOperation[A](
+    errorMessage: => String
+  )(operation: => A): Option[A] = Try(operation) match {
     case Success(value) => Option(value)
     case Failure(e) =>
       logger.error(errorMessage, e)
       None
   }
 
-  private def fromASGTags(credentials: => AWSCredentialsProvider): Option[AwsIdentity] = {
+  private def fromASGTags(
+    credentials: => AwsCredentialsProvider
+  ): Option[AwsIdentity] = {
     // We read tags from the AutoScalingGroup rather than the instance itself to avoid problems where the
     // tags have not been applied to the instance before we start up (they are eventually consistent)
-    def withOneOffAsgClient[T](f: AmazonAutoScaling => T): T = {
-      val asgClient: AmazonAutoScaling = AmazonAutoScalingClientBuilder
-        .standard()
-        .withRegion(region)
-        .withCredentials(credentials)
+    def withOneOffAsgClient[T](f: AutoScalingClient => T): T = {
+      val asgClient: AutoScalingClient = AutoScalingClient.builder
+        .region(Region.of(region))
+        .credentialsProvider(credentials)
         .build()
       val returned = f(asgClient)
-      asgClient.shutdown()
+      asgClient.close()
       returned
     }
 
-    def getTags(asgClient: AmazonAutoScaling, instanceId: String): Map[String, String] = {
-      val describeAutoScalingInstancesRequest = new DescribeAutoScalingInstancesRequest().withInstanceIds(instanceId)
-      val describeAutoScalingInstancesResult = asgClient.describeAutoScalingInstances(describeAutoScalingInstancesRequest)
-      val autoScalingGroupName = describeAutoScalingInstancesResult.getAutoScalingInstances.asScala.head.getAutoScalingGroupName
+    def getTags(asgClient: AutoScalingClient,
+                instanceId: String): Map[String, String] = {
+      val describeAutoScalingInstancesRequest =
+        DescribeAutoScalingInstancesRequest.builder
+          .instanceIds(instanceId)
+          .build()
+      val describeAutoScalingInstancesResult =
+        asgClient.describeAutoScalingInstances(
+          describeAutoScalingInstancesRequest
+        )
+      val autoScalingGroupName =
+        describeAutoScalingInstancesResult.autoScalingInstances.asScala.head.autoScalingGroupName
+      val describeAutoScalingGroupsRequest =
+        DescribeAutoScalingGroupsRequest.builder
+          .autoScalingGroupNames(autoScalingGroupName)
+          .build()
+      val describeAutoScalingGroupsResult =
+        asgClient.describeAutoScalingGroups(describeAutoScalingGroupsRequest)
+      val autoScalingGroup =
+        describeAutoScalingGroupsResult.autoScalingGroups.asScala.head
 
-      val describeAutoScalingGroupsRequest = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(autoScalingGroupName)
-      val describeAutoScalingGroupsResult = asgClient.describeAutoScalingGroups(describeAutoScalingGroupsRequest)
-      val autoScalingGroup = describeAutoScalingGroupsResult.getAutoScalingGroups.asScala.head
-
-      autoScalingGroup.getTags.asScala.map { t => t.getKey -> t.getValue }.toMap
+      autoScalingGroup.tags.asScala.map { t =>
+        t.key -> t.value
+      }.toMap
     }
 
     Option(EC2MetadataUtils.getInstanceId).map { instanceId =>
@@ -65,13 +85,13 @@ object AppIdentity {
         app = tags("App"),
         stack = tags("Stack"),
         stage = tags("Stage"),
-        region = Regions.getCurrentRegion.getName
+        region = EC2MetadataUtils.getEC2InstanceRegion
       )
     }
   }
 
-
-  private def getEnv(variableName: String): Option[String] = Option(System.getenv(variableName))
+  private def getEnv(variableName: String): Option[String] =
+    Option(System.getenv(variableName))
 
   private def fromLambdaEnvVariables(): Option[AppIdentity] = {
     for {
@@ -79,32 +99,30 @@ object AppIdentity {
       stack <- getEnv("Stack")
       stage <- getEnv("Stage")
       region <- getEnv("AWS_DEFAULT_REGION")
-    } yield AwsIdentity(
-      app = app,
-      stack = stack,
-      stage = stage,
-      region = region
-    )
+    } yield
+      AwsIdentity(app = app, stack = stack, stage = stage, region = region)
   }
 
-  private def fromTeamcityEnvVariables(defaultAppName: String): Option[AppIdentity] = {
+  private def fromTeamcityEnvVariables(
+    defaultAppName: String
+  ): Option[AppIdentity] = {
     for {
       _ <- getEnv("TEAMCITY_VERSION")
     } yield DevIdentity(defaultAppName)
   }
 
   def region: String = {
-    lazy val ec2Region = safeAwsOperation("Failed to identify the regionName of the instance") {
-      Option(Regions.getCurrentRegion).map(_.getName)
-    }.flatten
+    lazy val ec2Region =
+      safeAwsOperation("Failed to identify the regionName of the instance") {
+        EC2MetadataUtils.getEC2InstanceRegion
+      }
     lazy val lambdaRegion = Option(System.getenv("AWS_DEFAULT_REGION"))
     lambdaRegion orElse ec2Region getOrElse "eu-west-1"
   }
 
-  def whoAmI(
-              defaultAppName: String,
-              credentials: => AWSCredentialsProvider = DefaultAWSCredentialsProviderChain.getInstance
-            ): AppIdentity = {
+  def whoAmI(defaultAppName: String,
+             credentials: => AwsCredentialsProvider =
+               DefaultCredentialsProvider.create()): AppIdentity = {
     val result = fromTeamcityEnvVariables(defaultAppName)
       .orElse(fromLambdaEnvVariables())
       .orElse(fromASGTags(credentials))

--- a/core/src/main/scala/com/gu/conf/ConfigurationLoader.scala
+++ b/core/src/main/scala/com/gu/conf/ConfigurationLoader.scala
@@ -2,27 +2,34 @@ package com.gu.conf
 
 import java.io.File
 
-import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
 import com.gu.{AppIdentity, DevIdentity}
 import com.typesafe.config.Config
 import org.slf4j.LoggerFactory
+import software.amazon.awssdk.auth.credentials.{
+  AwsCredentialsProvider,
+  DefaultCredentialsProvider
+}
 
 object ConfigurationLoader {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private def defaultDevLocation(identity: DevIdentity): ConfigurationLocation = {
+  private def defaultDevLocation(
+    identity: DevIdentity
+  ): ConfigurationLocation = {
     val home = System.getProperty("user.home")
     FileConfigurationLocation(new File(s"$home/.gu/${identity.app}.conf"))
   }
 
   def load(
     identity: AppIdentity,
-    credentials: => AWSCredentialsProvider = DefaultAWSCredentialsProviderChain.getInstance
-  )(locationFunction: PartialFunction[AppIdentity, ConfigurationLocation] = PartialFunction.empty): Config = {
-    val getLocation = locationFunction.orElse[AppIdentity, ConfigurationLocation] {
-      case devIdentity: DevIdentity => defaultDevLocation(devIdentity)
-    }
+    credentials: => AwsCredentialsProvider = DefaultCredentialsProvider.create()
+  )(locationFunction: PartialFunction[AppIdentity, ConfigurationLocation] =
+      PartialFunction.empty): Config = {
+    val getLocation =
+      locationFunction.orElse[AppIdentity, ConfigurationLocation] {
+        case devIdentity: DevIdentity => defaultDevLocation(devIdentity)
+      }
 
     logger.info(s"Fetching configuration for $identity")
 

--- a/core/src/main/scala/com/gu/conf/ConfigurationLoader.scala
+++ b/core/src/main/scala/com/gu/conf/ConfigurationLoader.scala
@@ -14,9 +14,7 @@ object ConfigurationLoader {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private def defaultDevLocation(
-    identity: DevIdentity
-  ): ConfigurationLocation = {
+  private def defaultDevLocation(identity: DevIdentity): ConfigurationLocation = {
     val home = System.getProperty("user.home")
     FileConfigurationLocation(new File(s"$home/.gu/${identity.app}.conf"))
   }
@@ -24,12 +22,10 @@ object ConfigurationLoader {
   def load(
     identity: AppIdentity,
     credentials: => AwsCredentialsProvider = DefaultCredentialsProvider.create()
-  )(locationFunction: PartialFunction[AppIdentity, ConfigurationLocation] =
-      PartialFunction.empty): Config = {
-    val getLocation =
-      locationFunction.orElse[AppIdentity, ConfigurationLocation] {
-        case devIdentity: DevIdentity => defaultDevLocation(devIdentity)
-      }
+  )(locationFunction: PartialFunction[AppIdentity, ConfigurationLocation] = PartialFunction.empty): Config = {
+    val getLocation = locationFunction.orElse[AppIdentity, ConfigurationLocation] {
+      case devIdentity: DevIdentity => defaultDevLocation(devIdentity)
+    }
 
     logger.info(s"Fetching configuration for $identity")
 

--- a/core/src/main/scala/com/gu/conf/ConfigurationLocation.scala
+++ b/core/src/main/scala/com/gu/conf/ConfigurationLocation.scala
@@ -10,23 +10,18 @@ trait ConfigurationLocation {
 }
 
 case class FileConfigurationLocation(file: File) extends ConfigurationLocation {
-  override def load(credentials: => AwsCredentialsProvider): Config =
-    ConfigFactory.parseFile(file)
+  override def load(credentials: => AwsCredentialsProvider): Config = ConfigFactory.parseFile(file)
 }
 
-case class ResourceConfigurationLocation(resourceName: String)
-    extends ConfigurationLocation {
-  override def load(credentials: => AwsCredentialsProvider): Config =
-    ConfigFactory.parseResources(resourceName)
+case class ResourceConfigurationLocation(resourceName: String) extends ConfigurationLocation {
+  override def load(credentials: => AwsCredentialsProvider): Config = ConfigFactory.parseResources(resourceName)
 }
 
-case class ComposedConfigurationLocation(locations: List[ConfigurationLocation])
-    extends ConfigurationLocation {
+case class ComposedConfigurationLocation(locations: List[ConfigurationLocation]) extends ConfigurationLocation {
   override def load(credentials: => AwsCredentialsProvider): Config = {
-    val aggregatedConfig =
-      locations.map(_.load(credentials)).foldLeft(ConfigFactory.empty()) {
-        case (agg, loadedConfig) => agg.withFallback(loadedConfig)
-      }
+    val aggregatedConfig = locations.map(_.load(credentials)).foldLeft(ConfigFactory.empty()) {
+      case (agg, loadedConfig) => agg.withFallback(loadedConfig)
+    }
     aggregatedConfig.resolve()
   }
 }

--- a/core/src/main/scala/com/gu/conf/ConfigurationLocation.scala
+++ b/core/src/main/scala/com/gu/conf/ConfigurationLocation.scala
@@ -2,26 +2,31 @@ package com.gu.conf
 
 import java.io.File
 
-import com.amazonaws.auth.AWSCredentialsProvider
 import com.typesafe.config.{Config, ConfigFactory}
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 
 trait ConfigurationLocation {
-  def load(credentials: => AWSCredentialsProvider): Config
+  def load(credentials: => AwsCredentialsProvider): Config
 }
 
 case class FileConfigurationLocation(file: File) extends ConfigurationLocation {
-  override def load(credentials: => AWSCredentialsProvider): Config = ConfigFactory.parseFile(file)
+  override def load(credentials: => AwsCredentialsProvider): Config =
+    ConfigFactory.parseFile(file)
 }
 
-case class ResourceConfigurationLocation(resourceName: String) extends ConfigurationLocation {
-  override def load(credentials: => AWSCredentialsProvider): Config = ConfigFactory.parseResources(resourceName)
+case class ResourceConfigurationLocation(resourceName: String)
+    extends ConfigurationLocation {
+  override def load(credentials: => AwsCredentialsProvider): Config =
+    ConfigFactory.parseResources(resourceName)
 }
 
-case class ComposedConfigurationLocation(locations: List[ConfigurationLocation]) extends ConfigurationLocation {
-  override def load(credentials: => AWSCredentialsProvider): Config = {
-    val aggregatedConfig = locations.map(_.load(credentials)).foldLeft(ConfigFactory.empty()) {
-      case (agg, loadedConfig) => agg.withFallback(loadedConfig)
-    }
+case class ComposedConfigurationLocation(locations: List[ConfigurationLocation])
+    extends ConfigurationLocation {
+  override def load(credentials: => AwsCredentialsProvider): Config = {
+    val aggregatedConfig =
+      locations.map(_.load(credentials)).foldLeft(ConfigFactory.empty()) {
+        case (agg, loadedConfig) => agg.withFallback(loadedConfig)
+      }
     aggregatedConfig.resolve()
   }
 }

--- a/s3/src/main/scala/com/gu/conf/S3ConfigurationLocation.scala
+++ b/s3/src/main/scala/com/gu/conf/S3ConfigurationLocation.scala
@@ -1,42 +1,53 @@
 package com.gu.conf
 
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.gu.AwsIdentity
 import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions}
 import org.slf4j.LoggerFactory
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
-import scala.io.Source
-
-case class S3ConfigurationLocation(
-  bucket: String,
-  path: String,
-  region: String = Regions.getCurrentRegion.getName
-) extends ConfigurationLocation {
+case class S3ConfigurationLocation(bucket: String,
+                                   path: String,
+                                   region: String =
+                                     EC2MetadataUtils.getEC2InstanceRegion)
+    extends ConfigurationLocation {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  override def load(credentials: => AWSCredentialsProvider): Config = {
-    logger.info(s"Attempting to load configuration from S3 for bucket = $bucket path = $path and region = $region")
-    val s3Client = {
-      val builder = AmazonS3ClientBuilder.standard()
-      builder.setCredentials(credentials)
-      builder.setRegion(region)
-      builder.build()
-    }
+  override def load(credentials: => AwsCredentialsProvider): Config = {
+    logger.info(
+      s"Attempting to load configuration from S3 for bucket = $bucket path = $path and region = $region"
+    )
+    val s3Client = S3Client.builder
+      .credentialsProvider(credentials)
+      .region(Region.of(region))
+      .build()
 
-    val s3Object = s3Client.getObject(bucket, path)
-    val content = Source.fromInputStream(s3Object.getObjectContent).mkString
+    val content = s3Client
+      .getObjectAsBytes(
+        GetObjectRequest.builder.bucket(bucket).key(path).build()
+      )
+      .asString(UTF_8)
 
-    s3Client.shutdown()
+    s3Client.close()
 
-    ConfigFactory.parseString(content, ConfigParseOptions.defaults().setOriginDescription(s"s3://$bucket/$path"))
+    ConfigFactory.parseString(
+      content,
+      ConfigParseOptions.defaults().setOriginDescription(s"s3://$bucket/$path")
+    )
   }
 }
 
 object S3ConfigurationLocation {
   def default(identity: AwsIdentity): ConfigurationLocation = {
-    S3ConfigurationLocation(s"${identity.app}-dist", s"${identity.stage}/${identity.stack}/${identity.app}/${identity.app}.conf")
+    S3ConfigurationLocation(
+      s"${identity.app}-dist",
+      s"${identity.stage}/${identity.stack}/${identity.app}/${identity.app}.conf"
+    )
   }
 }

--- a/ssm/src/main/scala/com/gu/conf/SSMConfigurationLocation.scala
+++ b/ssm/src/main/scala/com/gu/conf/SSMConfigurationLocation.scala
@@ -1,56 +1,58 @@
 package com.gu.conf
 
-import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest
 import com.gu.{AppIdentity, AwsIdentity}
 import com.typesafe.config.{Config, ConfigFactory}
 import org.slf4j.LoggerFactory
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ssm.SsmClient
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest
 
-import scala.collection.JavaConverters._
 import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 
-case class SSMConfigurationLocation(
-  path: String,
-  region: String = AppIdentity.region
-) extends ConfigurationLocation {
+case class SSMConfigurationLocation(path: String,
+                                    region: String = AppIdentity.region)
+    extends ConfigurationLocation {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  override def load(credentials: => AWSCredentialsProvider): Config = {
-    logger.info(s"Attempting to load configuration from SSM for path = $path and region = $region")
-    val ssmClient = {
-      AWSSimpleSystemsManagementClientBuilder
-        .standard()
-        .withCredentials(credentials)
-        .withRegion(region)
-        .build()
-    }
+  override def load(credentials: => AwsCredentialsProvider): Config = {
+    logger.info(
+      s"Attempting to load configuration from SSM for path = $path and region = $region"
+    )
+    val ssmClient = SsmClient.builder
+      .credentialsProvider(credentials)
+      .region(Region.of(region))
+      .build()
 
     @tailrec
-    def recursiveParamFetch(parameters: Map[String, String], nextToken: Option[String]): Map[String, String] = {
+    def recursiveParamFetch(parameters: Map[String, String],
+                            nextToken: Option[String]): Map[String, String] = {
 
-      val parameterRequest = new GetParametersByPathRequest()
-        .withWithDecryption(true)
-        .withPath(path)
-        .withRecursive(true)
-        .withNextToken(nextToken.orNull)
+      val parameterRequest = GetParametersByPathRequest.builder
+        .withDecryption(true)
+        .path(path)
+        .recursive(true)
+        .nextToken(nextToken.orNull)
+        .build()
 
       val result = ssmClient.getParametersByPath(parameterRequest)
 
-      val results = result.getParameters.asScala.map {
-        p => p.getName.replaceFirst(s"$path/", "").replaceAll("/", ".") -> p.getValue
+      val results = result.parameters.asScala.map { p =>
+        p.name.replaceFirst(s"$path/", "").replaceAll("/", ".") -> p.value
       }.toMap
 
-      Option(result.getNextToken) match {
-        case Some(next) => recursiveParamFetch(parameters ++ results, Some(next))
+      Option(result.nextToken) match {
+        case Some(next) =>
+          recursiveParamFetch(parameters ++ results, Some(next))
         case None => parameters ++ results
       }
     }
 
     val parameters = recursiveParamFetch(Map.empty, None)
 
-    ssmClient.shutdown()
+    ssmClient.close()
 
     ConfigFactory.parseMap(parameters.asJava, "AWS SSM parameters")
   }
@@ -58,6 +60,8 @@ case class SSMConfigurationLocation(
 
 object SSMConfigurationLocation {
   def default(identity: AwsIdentity): ConfigurationLocation = {
-    SSMConfigurationLocation(s"/${identity.stage}/${identity.stack}/${identity.app}")
+    SSMConfigurationLocation(
+      s"/${identity.stage}/${identity.stack}/${identity.app}"
+    )
   }
 }

--- a/ssm/src/main/scala/com/gu/conf/SSMConfigurationLocation.scala
+++ b/ssm/src/main/scala/com/gu/conf/SSMConfigurationLocation.scala
@@ -11,24 +11,22 @@ import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
-case class SSMConfigurationLocation(path: String,
-                                    region: String = AppIdentity.region)
-    extends ConfigurationLocation {
+case class SSMConfigurationLocation(
+  path: String,
+  region: String = AppIdentity.region
+) extends ConfigurationLocation {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
   override def load(credentials: => AwsCredentialsProvider): Config = {
-    logger.info(
-      s"Attempting to load configuration from SSM for path = $path and region = $region"
-    )
+    logger.info(s"Attempting to load configuration from SSM for path = $path and region = $region")
     val ssmClient = SsmClient.builder
       .credentialsProvider(credentials)
       .region(Region.of(region))
       .build()
 
     @tailrec
-    def recursiveParamFetch(parameters: Map[String, String],
-                            nextToken: Option[String]): Map[String, String] = {
+    def recursiveParamFetch(parameters: Map[String, String], nextToken: Option[String]): Map[String, String] = {
 
       val parameterRequest = GetParametersByPathRequest.builder
         .withDecryption(true)
@@ -44,8 +42,7 @@ case class SSMConfigurationLocation(path: String,
       }.toMap
 
       Option(result.nextToken) match {
-        case Some(next) =>
-          recursiveParamFetch(parameters ++ results, Some(next))
+        case Some(next) => recursiveParamFetch(parameters ++ results, Some(next))
         case None => parameters ++ results
       }
     }
@@ -60,8 +57,6 @@ case class SSMConfigurationLocation(path: String,
 
 object SSMConfigurationLocation {
   def default(identity: AwsIdentity): ConfigurationLocation = {
-    SSMConfigurationLocation(
-      s"/${identity.stage}/${identity.stack}/${identity.app}"
-    )
+    SSMConfigurationLocation(s"/${identity.stage}/${identity.stack}/${identity.app}")
   }
 }


### PR DESCRIPTION
This will get rid of unsafe transitive dependencies in some downstream projects, 
such as https://github.com/guardian/support-service-lambdas.

See https://app.snyk.io/org/the-guardian-cuu/project/a9d22228-077a-48e4-8274-18b44e3daa9a/

Will also close issue https://github.com/guardian/simple-configuration/issues/10.
