### PR TITLE
Ignore BSP config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 target
+.bsp


### PR DESCRIPTION
#17 introduced [BSP](https://www.scala-lang.org/blog/2018/06/15/bsp.html) support.  The BSP config can be ignored.
