### PR TITLE
Bump dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ organization := "com.gu"
 
 val scala_2_11: String = "2.11.12"
 val scala_2_12: String = "2.12.12"
-val scala_2_13: String = "2.13.4"
+val scala_2_13: String = "2.13.5"
 
-val awsSdkVersion = "2.15.33"
+val awsSdkVersion = "2.16.7"
 
 scalaVersion := scala_2_11
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.3
+sbt.version = 1.4.7


### PR DESCRIPTION
This is to use AWS SDK v2.16 to avoid some jackson-databind vulnerabilities.