### PR TITLE
Publish to Sonatype instead of Bintray

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,10 +13,9 @@ It relies on [lightbend's configuration library](https://github.com/typesafehub/
 
 In your `build.sbt`:
 ```scala
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-libraryDependencies += "com.gu" %% "simple-configuration-s3" % "1.5.2"
+libraryDependencies += "com.gu" %% "simple-configuration-s3" % "1.5.4"
 // OR
-libraryDependencies += "com.gu" %% "simple-configuration-ssm" % "1.5.2"
+libraryDependencies += "com.gu" %% "simple-configuration-ssm" % "1.5.4"
 ```
 
 Then in your code:

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ val awsSdkVersion = "2.16.7"
 
 scalaVersion := scala_2_11
 
+publishTo in ThisBuild := sonatypePublishToBundle.value
+
 val sharedSettings = Seq(
   scalaVersion := scala_2_11,
   scalacOptions += "-target:jvm-1.8",
@@ -20,8 +22,6 @@ val sharedSettings = Seq(
     "http://www.apache.org/licenses/LICENSE-2.0.html"
   )),
   organization := "com.gu",
-  bintrayOrganization := Some("guardian"),
-  bintrayRepository := "platforms",
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
@@ -32,7 +32,6 @@ val sharedSettings = Seq(
     commitReleaseVersion,
     tagRelease,
     publishArtifacts,
-    releaseStepTask(bintrayRelease),
     setNextVersion,
     commitNextVersion,
     pushChanges

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
Bintray [is being sunsetted](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) so this change publishes to Sonatype instead.

I've tested it by publishing a [snapshot version](https://oss.sonatype.org/content/repositories/snapshots/com/gu/simple-configuration-core_2.11/1.5.5-SNAPSHOT6-SNAPSHOT).
