### PR TITLE
Fix ec2 metadata request for dev

### DIFF
--- a/core/src/main/scala/com/gu/AppIdentity.scala
+++ b/core/src/main/scala/com/gu/AppIdentity.scala
@@ -8,7 +8,6 @@ import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 import software.amazon.awssdk.services.autoscaling.model.{DescribeAutoScalingGroupsRequest, DescribeAutoScalingInstancesRequest}
 
 import scala.collection.JavaConverters._
-import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 sealed trait AppIdentity
@@ -74,7 +73,7 @@ object AppIdentity {
           region = EC2MetadataUtils.getEC2InstanceRegion
         ))
       case Success(None) => None
-      case Failure(NonFatal(err)) =>
+      case Failure(err) =>
         logger.warn(s"Failed to get instance id from ec2 metadata service: ${err.getMessage}", err)
         None
     }


### PR DESCRIPTION
Since the aws sdk update, this produces the following error when run locally:
```
software.amazon.awssdk.core.exception.SdkClientException: Unable to contact EC2 metadata service.

     software.amazon.awssdk.core.exception.SdkClientException$BuilderImpl.build(SdkClientException.java:98)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.getItems(EC2MetadataUtils.java:400)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.getItems(EC2MetadataUtils.java:432)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.getItems(EC2MetadataUtils.java:432)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.getItems(EC2MetadataUtils.java:432)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:378)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.getData(EC2MetadataUtils.java:374)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.fetchData(EC2MetadataUtils.java:472)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.fetchData(EC2MetadataUtils.java:462)

     software.amazon.awssdk.regions.internal.util.EC2MetadataUtils.getInstanceId(EC2MetadataUtils.java:140)

     com.gu.AppIdentity$.fromASGTags(AppIdentity.scala:70)
```

It's because the sdk call used to return `null`, but now throws an exception. I've changed it to handle both cases.
Note that it will always log the exception in DEV now, but there is a log immediately after saying `s"Detected the following AppIdentity: $result"`