### PR TITLE
Publshing tweak as it doesn't seem reliable at the moment

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,15 @@
 
 _A configuration library without any magic_
 
+## Releasing
+
+There's something strange about releasing, meaning if you do `release` at the root, it doesn't actually
+publish the artifacts to sonatype.  It seems like then running the release again at the same version in
+one of the subprojects will actually release everything.  Please update this paragraph and the build.sbt
+if you work out anything more useful!
+I have updated the build.sbt from `publishTo := sonatypePublishToBundle.value` to `publishTo := sonatypePublishTo.value`
+as advised on Engineering chat.
+
 ## Goal
 This library will help you load the configuration of your application from S3 or the SSM parameter store.
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val awsSdkVersion = "2.16.7"
 
 scalaVersion := scala_2_11
 
-publishTo in ThisBuild := sonatypePublishToBundle.value
+publishTo in ThisBuild := sonatypePublishTo.value
 
 val sharedSettings = Seq(
   scalaVersion := scala_2_11,

--- a/ssm/version.sbt
+++ b/ssm/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.6"
+version in ThisBuild := "1.5.7-SNAPSHOT"

--- a/ssm/version.sbt
+++ b/ssm/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.5.6"

--- a/ssm/version.sbt
+++ b/ssm/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.5.7-SNAPSHOT"


### PR DESCRIPTION
This PR updates the publshing task as discussed on Engineering chat channel.  I have also added comments to the readme to help the next person.

I changed this because for some reason releasing at the root packaged all the versions up for everything, but didn't actually send to sonatype.
When I tried the release process on one submodule, it seemed to release everything.
Others were having related problems and that change was required to the build.sbt, so I have added that for the benefit of the next person!