### PR TITLE
Prevent excessive delay when starting the app locally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,20 +18,19 @@ ThisBuild / developers := List(Developer(
   url = url("https://github.com/guardian")
 ))
 
-val scala_2_11: String = "2.11.12"
 val scala_2_12: String = "2.12.12"
-val scala_2_13: String = "2.13.5"
+val scala_2_13: String = "2.13.6"
 
 val awsSdkVersion = "2.16.7"
 
-scalaVersion := scala_2_11
+scalaVersion := scala_2_13
 
-publishTo in ThisBuild := sonatypePublishTo.value
+ThisBuild / publishTo := sonatypePublishTo.value
 
 val sharedSettings = Seq(
-  scalaVersion := scala_2_11,
+  scalaVersion := scala_2_13,
   scalacOptions += "-target:jvm-1.8",
-  crossScalaVersions := Seq(scala_2_11, scala_2_12, scala_2_13),
+  crossScalaVersions := Seq(scala_2_12, scala_2_13),
   releaseCrossBuild := true,
   licenses += ("Apache-2.0", url(
     "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -90,5 +89,5 @@ lazy val root = project
   .settings(
     publish := {},
     releaseCrossBuild := true,
-    crossScalaVersions := Seq(scala_2_11, scala_2_12, scala_2_13)
+    crossScalaVersions := Seq(scala_2_12, scala_2_13)
   )

--- a/s3/src/main/scala/com/gu/conf/S3ConfigurationLocation.scala
+++ b/s3/src/main/scala/com/gu/conf/S3ConfigurationLocation.scala
@@ -1,20 +1,19 @@
 package com.gu.conf
 
-import java.nio.charset.StandardCharsets.UTF_8
-
 import com.gu.AwsIdentity
 import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions}
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+
+import java.nio.charset.StandardCharsets.UTF_8
 
 case class S3ConfigurationLocation(
   bucket: String,
   path: String,
-  region: String = EC2MetadataUtils.getEC2InstanceRegion
+  region: String
 ) extends ConfigurationLocation {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -38,6 +37,6 @@ case class S3ConfigurationLocation(
 
 object S3ConfigurationLocation {
   def default(identity: AwsIdentity): ConfigurationLocation = {
-    S3ConfigurationLocation(s"${identity.app}-dist", s"${identity.stage}/${identity.stack}/${identity.app}/${identity.app}.conf")
+    S3ConfigurationLocation(s"${identity.app}-dist", s"${identity.stage}/${identity.stack}/${identity.app}/${identity.app}.conf", identity.region)
   }
 }

--- a/ssm/src/main/scala/com/gu/conf/SSMConfigurationLocation.scala
+++ b/ssm/src/main/scala/com/gu/conf/SSMConfigurationLocation.scala
@@ -1,6 +1,6 @@
 package com.gu.conf
 
-import com.gu.{AppIdentity, AwsIdentity}
+import com.gu.AwsIdentity
 import com.typesafe.config.{Config, ConfigFactory}
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
@@ -13,7 +13,7 @@ import scala.collection.JavaConverters._
 
 case class SSMConfigurationLocation(
   path: String,
-  region: String = AppIdentity.region
+  region: String
 ) extends ConfigurationLocation {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -57,6 +57,6 @@ case class SSMConfigurationLocation(
 
 object SSMConfigurationLocation {
   def default(identity: AwsIdentity): ConfigurationLocation = {
-    SSMConfigurationLocation(s"/${identity.stage}/${identity.stack}/${identity.app}")
+    SSMConfigurationLocation(s"/${identity.stage}/${identity.stack}/${identity.app}", identity.region)
   }
 }


### PR DESCRIPTION
This PR changes the `EC2MetadataUtils` calls to only happen if you pass isDev = false to the app identity.

This is because there seemed to be a 7+ second delay/timeout when calling it from a local play server.  We in support-frontend were calling two operations that used `EC2MetadataUtils` indirectly, so we were receiving a punishing 15 second delay when changing anything and recompiling!

The extra parameter would have to be added by anyone upgrading, so hopefully everyone will avoid the similar timeout once they bump the version.