### PR TITLE
Bump AWS SDK To 2.17.73

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ val scala_2_11: String = "2.11.12"
 val scala_2_12: String = "2.12.12"
 val scala_2_13: String = "2.13.5"
 
-val awsSdkVersion = "2.16.7"
+val awsSdkVersion = "2.17.73"
 
 scalaVersion := scala_2_11
 


### PR DESCRIPTION
## What does this change?

Bump AWS SDK to 2.17.73.

## How to test

Projects that use this library continue to work as expected.

## How can we measure success?

We're on the latest version of the SDK and everything still works.

## Have we considered potential risks?

Projects that use this library have trouble upgrading.
