### PR TITLE
drop support for scala 2.11 and bump minor versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,20 +18,19 @@ ThisBuild / developers := List(Developer(
   url = url("https://github.com/guardian")
 ))
 
-val scala_2_11: String = "2.11.12"
-val scala_2_12: String = "2.12.12"
-val scala_2_13: String = "2.13.5"
+val scala_2_12: String = "2.12.15"
+val scala_2_13: String = "2.13.7"
 
 val awsSdkVersion = "2.17.73"
 
-scalaVersion := scala_2_11
+scalaVersion := scala_2_13
 
-publishTo in ThisBuild := sonatypePublishTo.value
+ThisBuild / publishTo := sonatypePublishTo.value
 
 val sharedSettings = Seq(
-  scalaVersion := scala_2_11,
+  scalaVersion := scala_2_13,
   scalacOptions += "-target:jvm-1.8",
-  crossScalaVersions := Seq(scala_2_11, scala_2_12, scala_2_13),
+  crossScalaVersions := Seq(scala_2_12, scala_2_13),
   releaseCrossBuild := true,
   licenses += ("Apache-2.0", url(
     "http://www.apache.org/licenses/LICENSE-2.0.html"
@@ -90,5 +89,5 @@ lazy val root = project
   .settings(
     publish := {},
     releaseCrossBuild := true,
-    crossScalaVersions := Seq(scala_2_11, scala_2_12, scala_2_13)
+    crossScalaVersions := Seq(scala_2_12, scala_2_13)
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.7
+sbt.version = 1.5.5


### PR DESCRIPTION
This PR drops support for scala 2.11 and bumps the minor versions.  This was an opportunistic part of https://github.com/guardian/simple-configuration/pull/25 however it was suggested to split it out to make things clearer.