### PR TITLE
Discourage usage that causes long startup delays

### DIFF
--- a/core/src/main/scala/com/gu/AppIdentity.scala
+++ b/core/src/main/scala/com/gu/AppIdentity.scala
@@ -26,12 +26,11 @@ case class DevIdentity(app: String) extends AppIdentity
 object AppIdentity {
   private val logger = LoggerFactory.getLogger(this.getClass)
 
-  private def safeAwsOperation[A](errorMessage: => String)(operation: => A): Try[A] =
-    Try(operation).recoverWith {
-      case e: Throwable =>
-        logger.error(errorMessage, e)
-        Failure(e)
-    }
+  private def safeAwsOperation[A](errorMessage: => String)(operation: => A): Try[A] = {
+    val result = Try(operation)
+    result.failed.foreach(e => logger.error(errorMessage, e))
+    result
+  }
 
   private def fromASGTags(credentials: => AwsCredentialsProvider): Try[AwsIdentity] = {
     // We read tags from the AutoScalingGroup rather than the instance itself to avoid problems where the

--- a/s3/src/main/scala/com/gu/conf/S3ConfigurationLocation.scala
+++ b/s3/src/main/scala/com/gu/conf/S3ConfigurationLocation.scala
@@ -7,14 +7,13 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions}
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
 case class S3ConfigurationLocation(
   bucket: String,
   path: String,
-  region: String = EC2MetadataUtils.getEC2InstanceRegion
+  region: String
 ) extends ConfigurationLocation {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -37,7 +36,11 @@ case class S3ConfigurationLocation(
 }
 
 object S3ConfigurationLocation {
-  def default(identity: AwsIdentity): ConfigurationLocation = {
-    S3ConfigurationLocation(s"${identity.app}-dist", s"${identity.stage}/${identity.stack}/${identity.app}/${identity.app}.conf")
-  }
+  def default(identity: AwsIdentity): ConfigurationLocation =
+    S3ConfigurationLocation(
+      bucket = s"${identity.app}-dist",
+      path = s"${identity.stage}/${identity.stack}/${identity.app}/${identity.app}.conf",
+      region = identity.region
+    )
+
 }

--- a/ssm/src/main/scala/com/gu/conf/SSMConfigurationLocation.scala
+++ b/ssm/src/main/scala/com/gu/conf/SSMConfigurationLocation.scala
@@ -1,6 +1,6 @@
 package com.gu.conf
 
-import com.gu.{AppIdentity, AwsIdentity}
+import com.gu.AwsIdentity
 import com.typesafe.config.{Config, ConfigFactory}
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
@@ -13,7 +13,7 @@ import scala.collection.JavaConverters._
 
 case class SSMConfigurationLocation(
   path: String,
-  region: String = AppIdentity.region
+  region: String
 ) extends ConfigurationLocation {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -56,7 +56,7 @@ case class SSMConfigurationLocation(
 }
 
 object SSMConfigurationLocation {
-  def default(identity: AwsIdentity): ConfigurationLocation = {
-    SSMConfigurationLocation(s"/${identity.stage}/${identity.stack}/${identity.app}")
-  }
+  def default(identity: AwsIdentity): ConfigurationLocation =
+    SSMConfigurationLocation(s"/${identity.stage}/${identity.stack}/${identity.app}", identity.region)
+
 }


### PR DESCRIPTION
## What does this change?

replacing this previous pr https://github.com/guardian/simple-configuration/pull/25

This PR changes the whoAmI function so it should not be called from DEV.  It will return a Try.failure with a descriptive message, which will hopefully encourage people to shortcut the call if running in DEV.

This is because some apps used by supporter revenue and by mobile are spending a lot of time to start in DEV, which is unnecessary.