### PR TITLE
Update example code for Play Framework

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -150,7 +150,7 @@ class MyApplicationLoader extends ApplicationLoader {
     val loadedConfig = ConfigurationLoader.load(identity) {
       case identity: AwsIdentity => S3ConfigurationLocation.default(identity)
     }
-    val newContext = context.copy(initialConfiguration = context.initialConfiguration ++ Configuration(loadedConfig))
+    val newContext = context.copy(initialConfiguration = Configuration(loadedConfig).withFallback(context.initialConfiguration))
     (new BuiltInComponentsFromContext(newContext) with AppComponents).application
   }
 }


### PR DESCRIPTION
Some of the example code is using functionality that has been [deprecated](https://github.com/playframework/playframework/blob/78bcdb4e1d1fe0a350ab2a56a38649571415383f/core/play/src/main/scala/play/api/Configuration.scala#L186-L193) by the Play Framework. This PR updates the example to use Play 2.8's recommended approach.
