### PR TITLE
ci: Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+# Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      # See https://github.com/actions/setup-java
+      - name: Setup Java 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'corretto'
+          cache: 'sbt'
+
+      - name: Build
+        run: |
+          sbt clean compile test
+


### PR DESCRIPTION
Co-authored-by: @akash1810 

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Currently there is no CI workflow for this repo. 

This PR adds this so that we can ensure code compiles before releasing.

## How to test

See the CI workflow complete successfully in this PR.

