### PR TITLE
docs: Update README about releasing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ _A configuration library without any magic_
 
 ## Releasing
 
-Run `sbt release` at the root to publish the artifacts to sonatype.
+Run `sbt release` at the root to publish the artifacts to sonatype. For instructions on how to set up publishing, visit [this doc](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit).
 
 ## Goal
 This library will help you load the configuration of your application from S3 or the SSM parameter store.

--- a/Readme.md
+++ b/Readme.md
@@ -6,12 +6,7 @@ _A configuration library without any magic_
 
 ## Releasing
 
-There's something strange about releasing, meaning if you do `release` at the root, it doesn't actually
-publish the artifacts to sonatype.  It seems like then running the release again at the same version in
-one of the subprojects will actually release everything.  Please update this paragraph and the build.sbt
-if you work out anything more useful!
-I have updated the build.sbt from `publishTo := sonatypePublishToBundle.value` to `publishTo := sonatypePublishTo.value`
-as advised on Engineering chat.
+Run `sbt release` at the root to publish the artifacts to sonatype.
 
 ## Goal
 This library will help you load the configuration of your application from S3 or the SSM parameter store.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

After completing a release recently, it became apparent that the instructions were out of date. The release worked from the root of the repo. This updates the README to remove the redundant instructions.

## How can we measure success?

Users can follow the instructions and release successfully.