### PR TITLE
Update Java runtime from 8 to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v3
 
       # See https://github.com/actions/setup-java
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'corretto'
           cache: 'sbt'
 

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,6 @@ ThisBuild / publishTo := sonatypePublishTo.value
 
 val sharedSettings = Seq(
   scalaVersion := scala_2_13,
-  scalacOptions += "-target:jvm-1.8",
   crossScalaVersions := Seq(scala_2_12, scala_2_13),
   releaseCrossBuild := true,
   licenses += ("Apache-2.0", url(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This updates the Java runtime in the GH action from v8 to v11.

## How to test

See if this change passes the CI check.
