### PR TITLE
chore: Add Scala Steward conf to reduce PR frequency to weekly

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,6 @@
+pullRequests.frequency = "7 days"
+
+pullRequests.grouping = [
+  { name = "aws", "title" = "AWS dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
+  { name = "non_aws", "title" = "Non-AWS dependency updates", "filter" = [{"group" = "*"}] }
+]


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds  a Scala Steward conf file to raise PRs on a 7-day basis.

## How to test
Merge this PR and see if we get PRs raised only weekly for this repo, one for AWS deps and one for non-AWS.
