### PR TITLE
fix: Delete version.sbt in core project

### DIFF
--- a/core/version.sbt
+++ b/core/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "1.6.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.6.1-SNAPSHOT"
+ThisBuild / version := "1.6.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.6.0"
+ThisBuild / version := "1.6.1-SNAPSHOT"


### PR DESCRIPTION
Co-authored-by: @nicl 

## What does this change?

This PR removes a redundant `version.sbt` file in the `core` sub-project. The root `version.sbt` is the required file. 

We successfully released v1.6.0 from this branch.