### PR TITLE
chore: Release version 1.6.2 and update README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,10 @@ _A configuration library without any magic_
 ## Releasing
 
 Run `sbt release` at the root to publish the artifacts to sonatype. For instructions on how to set up publishing, visit [this doc](https://docs.google.com/document/d/1rNXjoZDqZMsQblOVXPAIIOMWuwUKe3KzTCttuqS7AcY/edit).
-Once the release is complete, push the automated commit to `main` which updated `version.sbt` as part of the release process.
+
+[!IMPORTANT]
+For some reason, releases are not promoted from staging, so you will need to do this manually if you notice your package sitting in [staging](https://oss.sonatype.org/#stagingRepositories). First 'close' the staged package, then choose 'release' and this will promote it to Maven.
+Our investigations imply that the `releaseStepCommand("sonatypeBundleRelease")` step is not running during release, but this has not been fully investigated for time reasons.
 
 ## Goal
 This library will help you load the configuration of your application from S3 or the SSM parameter store.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.6.1-SNAPSHOT"
+ThisBuild / version := "1.6.3-SNAPSHOT"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

After release of v.1.6.2 from this branch, this PR updates the README to capture the current release process. The version has also been bumped in `version.sbt`.

