### PR TITLE
Bump AWS SDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ ThisBuild / developers := List(Developer(
 val scala_2_12: String = "2.12.18"
 val scala_2_13: String = "2.13.12"
 
-val awsSdkVersion = "2.20.162"
+val awsSdkVersion = "2.21.13"
 
 scalaVersion := scala_2_13
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Version 2.21.13 is the latest

It seems that scala steward is not willing to bump minor versions

## How to test

No idea, we need help! @guardian/developer-experience 

There are no defined code owners so unsure exactly who’s best placed to review.

## How can we measure success?

Things updated are things loved.