### PR TITLE
feat: add Scala release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,7 @@
 import ReleaseTransformations._
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name := "simple-configuration"
-
-ThisBuild / scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/guardian/simple-configuration"),
-    "scm:git@github.com:guardian/simple-configuration.git"
-  )
-)
-
-ThisBuild / homepage := Some(url("https://github.com/guardian/simple-configuration"))
-
-ThisBuild / developers := List(Developer(
-  id = "Guardian",
-  name = "Guardian",
-  email = null,
-  url = url("https://github.com/guardian")
-))
 
 val scala_2_12: String = "2.12.19"
 val scala_2_13: String = "2.13.13"
@@ -25,15 +10,11 @@ val awsSdkVersion = "2.23.21"
 
 scalaVersion := scala_2_13
 
-ThisBuild / publishTo := sonatypePublishTo.value
-
 val sharedSettings = Seq(
   scalaVersion := scala_2_13,
   crossScalaVersions := Seq(scala_2_12, scala_2_13),
   releaseCrossBuild := true,
-  licenses += ("Apache-2.0", url(
-    "http://www.apache.org/licenses/LICENSE-2.0.html"
-  )),
+  licenses := Seq(License.Apache2),
   organization := "com.gu",
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseProcess := Seq[ReleaseStep](
@@ -44,12 +25,10 @@ val sharedSettings = Seq(
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,
-    releaseStepCommandAndRemaining("+publishSigned"),
-    releaseStepCommand("sonatypeBundleRelease"),
     setNextVersion,
-    commitNextVersion,
-    pushChanges
-  )
+    commitNextVersion
+  ),
+  scalacOptions := Seq("-release:11")
 )
 
 val core = project
@@ -86,7 +65,8 @@ lazy val root = project
   .in(file("."))
   .aggregate(core, s3, ssm)
   .settings(
-    publish := {},
+    publish / skip := true,
     releaseCrossBuild := true,
-    crossScalaVersions := Seq(scala_2_12, scala_2_13)
+    crossScalaVersions := Seq(scala_2_12, scala_2_13),
+    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
   )

--- a/build.sbt
+++ b/build.sbt
@@ -13,20 +13,8 @@ scalaVersion := scala_2_13
 val sharedSettings = Seq(
   scalaVersion := scala_2_13,
   crossScalaVersions := Seq(scala_2_12, scala_2_13),
-  releaseCrossBuild := true,
   licenses := Seq(License.Apache2),
   organization := "com.gu",
-  releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean,
-    runTest,
-    setReleaseVersion,
-    commitReleaseVersion,
-    tagRelease,
-    setNextVersion,
-    commitNextVersion
-  ),
   scalacOptions := Seq("-release:11")
 )
 
@@ -66,6 +54,17 @@ lazy val root = project
   .settings(
     publish / skip := true,
     releaseCrossBuild := true,
+    releaseProcess := Seq[ReleaseStep](
+      checkSnapshotDependencies,
+      inquireVersions,
+      runClean,
+      runTest,
+      setReleaseVersion,
+      commitReleaseVersion,
+      tagRelease,
+      setNextVersion,
+      commitNextVersion
+    ),
     crossScalaVersions := Seq(scala_2_12, scala_2_13),
     releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
   )

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ val sharedSettings = Seq(
   releaseCrossBuild := true,
   licenses := Seq(License.Apache2),
   organization := "com.gu",
-  releasePublishArtifactsAction := PgpKeys.publishSigned.value,
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,
     inquireVersions,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the Scala release workflow to allow for releasing to Sonatype via running a GH action.

## How to test

Post-merge, run the release workflow as per the [instructions](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/making-a-release.md).

## How can we measure success?

This really improves the release process for this library, and should make it a lot easier to make a release.