### PR TITLE
Update aws sdk to fix netty vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name := "simple-configuration"
 
-val awsSdkVersion = "2.29.6"
+val awsSdkVersion = "2.29.17"
 
 scalaVersion := "2.13.15"
 


### PR DESCRIPTION
## What does this change?

Updating the aws sdk to the newest version updates its transitive dependency on netty above 4.1.115, resolving [a high-severity vulnerability identified by dependabot](https://github.com/guardian/simple-configuration/security/dependabot/1).

## How to test

We feel this is a straightforward dependency update (patch version), so doesn’t require significant testing.