### PR TITLE
Fix CI for ubuntu-24.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      # See https://github.com/actions/setup-java
-      - name: Setup Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'corretto'
-          cache: 'sbt'
+      - uses: guardian/setup-scala@v1
 
       - name: Build
         run: |


### PR DESCRIPTION
## What does this change?

Github have just updated ubuntu-latest runners to use the new ubuntu-24.04 images again, with their reduced set of software pre-installed. The CI on this repo [has started failing](https://github.com/guardian/simple-configuration/actions/runs/12294247280/job/34308640373?pr=103) as a result, because it relies on sbt being installed by default.

To fix this, this PR replaces the use of actions/setup-java with our own action [guardian/setup-scala](https://github.com/guardian/setup-scala), which we’ve been using for this purpose. It installs both Java and sbt, and configures the Java version from the .tool-versions file in the repository.

This does mean that this change moves the CI from using Java 11 to Java 21: hopefully this is not a problem.

## How to test

- CI on this branch should run successfully