### PR TITLE
adding missing bracket

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ val config =
      AppIdentity.whoAmI(defaultAppName = "support-frontend", CredentialsProvider)
    config <- Try(ConfigurationLoader.load(identity, CredentialsProvider) {
      case identity: AwsIdentity => S3ConfigurationLocation.default(identity)
-   }
+   })
   } yield config
 ```
 


### PR DESCRIPTION
The code in the readme didn't compile due to a missing bracket.  This PR fixes that.

I think there's a docs plugin that can make the code compile (and even run) in the docs, which would make sense for something like this.  Tests are documentation after all!