### PR TITLE
remove huge ec2 library and replace with regions lib instead

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val core = project
   .settings(
     name := "simple-configuration-core",
     libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "ec2" % awsSdkVersion,
+      "software.amazon.awssdk" % "regions" % awsSdkVersion,
       "software.amazon.awssdk" % "autoscaling" % awsSdkVersion,
       "com.typesafe" % "config" % "1.4.3",
       "org.slf4j" % "slf4j-api" % "2.0.17"


### PR DESCRIPTION
One of our lambdas refused to deploy because its unzipped size was over 250MB.

Having looked into the jar it seemed there was a main offender of the AWS sdk software.amazon.awssdk with 159MB.  (The second offender was the stripe SDK com.stripe.* with 51MB)
```
% du -sh *|grep 'M\t'|sort -nr
159M    software
 67M    com
 52M    cats
 38M    scala
 21M    io
 13M    shapeless
```

having drilled all the way down, it's mostly the ec2 library
```
% pwd
[...]/software/amazon/awssdk/services
% du -sh *|grep 'M\t'|sort -nr
 90M    ec2
 26M    ssm
 16M    s3
9.8M    autoscaling
%
```

which comes via simple-configuration-core
```
[IJ]whatDependsOn software.amazon.awssdk ec2
[info] software.amazon.awssdk:ec2:2.30.38
[info]   +-com.gu:simple-configuration-core_2.13:5.0.2 [S]
[info]     +-com.gu:simple-configuration-ssm_2.13:5.0.2 [S]
[info]       +-com.gu:config-cats_2.13:0.0.1 [S]
[info]         +-com.gu:stripe-webhook-endpoints_2.13:0.0.1 [S]
```

It turns out that we only need the EC2MetadataUtils class which comes from "regions" lib 

![image](https://github.com/user-attachments/assets/80284b8f-21da-444d-b609-9be542dacd42)


This PR changes the dep from ec2 to regions.
